### PR TITLE
Add AWS Lambda login native Android app

### DIFF
--- a/NativeLoginApp/app/build.gradle
+++ b/NativeLoginApp/app/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
+}
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        applicationId "com.example.login"
+        minSdkVersion 21
+        targetSdkVersion 33
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.4.7'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation 'androidx.compose.ui:ui:1.3.1'
+    implementation 'androidx.compose.ui:ui-tooling-preview:1.3.1'
+    implementation 'androidx.compose.material:material:1.3.1'
+    implementation 'androidx.navigation:navigation-compose:2.5.3'
+    implementation 'com.google.dagger:hilt-android:2.44'
+    kapt 'com.google.dagger:hilt-android-compiler:2.44'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    implementation 'com.amazonaws:aws-android-sdk-core:2.57.0'
+    implementation 'com.amazonaws:aws-android-sdk-cognitoauth:2.57.0'
+}
+
+apply plugin: 'com.google.dagger.hilt.android'

--- a/NativeLoginApp/app/src/main/AndroidManifest.xml
+++ b/NativeLoginApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.login">
+
+    <application
+        android:name="com.example.login.LoginApp"
+        android:label="LoginApp"
+        android:theme="@style/Theme.MaterialComponents.Light.NoActionBar">
+        <activity android:name="com.example.login.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/NativeLoginApp/app/src/main/java/com/example/login/AWSCredentialManager.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/AWSCredentialManager.kt
@@ -1,0 +1,30 @@
+package com.example.login
+
+import android.content.Context
+import com.amazonaws.auth.CognitoCachingCredentialsProvider
+import com.amazonaws.mobile.config.AWSConfiguration
+import com.amazonaws.mobile.client.AWSMobileClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AWSCredentialManager(context: Context) {
+    private val awsConfig = AWSConfiguration(context)
+    private val credentialsProvider = CognitoCachingCredentialsProvider(
+        context,
+        awsConfig
+    )
+
+    private val _sessionToken = MutableStateFlow<String?>(null)
+    val sessionToken: StateFlow<String?> = _sessionToken.asStateFlow()
+
+    suspend fun getCredentials() {
+        val creds = credentialsProvider.credentials
+        _sessionToken.value = creds.sessionToken
+    }
+
+    suspend fun refreshCredentials() {
+        credentialsProvider.refresh()
+        getCredentials()
+    }
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginApp.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginApp.kt
@@ -1,0 +1,7 @@
+package com.example.login
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class LoginApp : Application()

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginEffect.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginEffect.kt
@@ -1,0 +1,5 @@
+package com.example.login
+
+sealed class LoginEffect {
+    object NavigateOtp : LoginEffect()
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginEvent.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginEvent.kt
@@ -1,0 +1,6 @@
+package com.example.login
+
+sealed class LoginEvent {
+    data class PhoneChanged(val phone: String) : LoginEvent()
+    object SendOtp : LoginEvent()
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginRepository.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginRepository.kt
@@ -1,0 +1,32 @@
+package com.example.login
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.Headers
+import retrofit2.http.POST
+
+interface LoginApi {
+    @POST("send-otp")
+    suspend fun sendOtp(@Body body: Map<String, String>)
+}
+
+class LoginRepository(private val credentialManager: AWSCredentialManager) {
+    private val api: LoginApi
+
+    init {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("https://example.com/") // placeholder
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        api = retrofit.create(LoginApi::class.java)
+    }
+
+    suspend fun sendOtp(phone: String) = withContext(Dispatchers.IO) {
+        val token = credentialManager.sessionToken.value ?: ""
+        // Normally you'd add dynamic headers with an interceptor
+        api.sendOtp(mapOf("phone" to phone))
+    }
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginScreen.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginScreen.kt
@@ -1,0 +1,46 @@
+package com.example.login
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun LoginScreen(viewModel: LoginViewModel = hiltViewModel(), navigateOtp: () -> Unit) {
+    val state = viewModel.state.collectAsState().value
+
+    if (state is LoginState.Success) {
+        navigateOtp()
+    }
+
+    Column(Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = viewModel.phone,
+            onValueChange = { viewModel.onEvent(LoginEvent.PhoneChanged(it)) },
+            label = { Text("Phone") },
+            keyboardOptions = androidx.compose.ui.text.input.KeyboardOptions.Default.copy(keyboardType = KeyboardType.Phone)
+        )
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = { viewModel.onEvent(LoginEvent.SendOtp) }) {
+            if (state is LoginState.Loading) {
+                CircularProgressIndicator(Modifier.size(24.dp))
+            } else {
+                Text("Send OTP")
+            }
+        }
+        if (state is LoginState.Error) {
+            Text(state.message, color = MaterialTheme.colors.error)
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LoginPreview() {
+    LoginScreen(navigateOtp = {})
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginState.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginState.kt
@@ -1,0 +1,8 @@
+package com.example.login
+
+sealed class LoginState {
+    object Idle : LoginState()
+    object Loading : LoginState()
+    object Success : LoginState()
+    data class Error(val message: String) : LoginState()
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/LoginViewModel.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/LoginViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val repository: LoginRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<LoginState>(LoginState.Idle)
+    val state: StateFlow<LoginState> = _state
+
+    private val _effect = MutableSharedFlow<LoginEffect>()
+    val effect = _effect.asSharedFlow()
+
+    var phone: String = ""
+        private set
+
+    fun onEvent(event: LoginEvent) {
+        when (event) {
+            is LoginEvent.PhoneChanged -> phone = event.phone
+            LoginEvent.SendOtp -> sendOtp()
+        }
+    }
+
+    private fun sendOtp() {
+        viewModelScope.launch {
+            _state.value = LoginState.Loading
+            try {
+                repository.sendOtp(phone)
+                _state.value = LoginState.Success
+                _effect.emit(LoginEffect.NavigateOtp)
+            } catch (e: Exception) {
+                _state.value = LoginState.Error(e.message ?: "Unknown error")
+            }
+        }
+    }
+}

--- a/NativeLoginApp/app/src/main/java/com/example/login/MainActivity.kt
+++ b/NativeLoginApp/app/src/main/java/com/example/login/MainActivity.kt
@@ -1,0 +1,53 @@
+package com.example.login
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppNavigator()
+        }
+    }
+}
+
+@Composable
+fun AppNavigator() {
+    val navController = rememberNavController()
+    NavHost(navController, startDestination = "login") {
+        composable("login") {
+            LoginScreen(navigateOtp = { navController.navigate("otp") })
+        }
+        composable("otp") {
+            OTPScreen()
+        }
+    }
+}
+
+@Composable
+fun OTPScreen() {
+    Surface {
+        Text("OTP Screen")
+    }
+}
+
+@Preview
+@Composable
+fun DefaultPreview() {
+    AppNavigator()
+}

--- a/NativeLoginApp/app/src/main/res/raw/AWSConfiguration.json
+++ b/NativeLoginApp/app/src/main/res/raw/AWSConfiguration.json
@@ -1,0 +1,10 @@
+{
+  "CredentialsProvider": {
+    "CognitoIdentity": {
+      "Default": {
+        "PoolId": "us-east-1:example-pool-id",
+        "Region": "us-east-1"
+      }
+    }
+  }
+}

--- a/NativeLoginApp/app/src/main/res/values/strings.xml
+++ b/NativeLoginApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">LoginApp</string>
+</resources>

--- a/NativeLoginApp/app/src/main/res/values/themes.xml
+++ b/NativeLoginApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LoginApp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/NativeLoginApp/build.gradle
+++ b/NativeLoginApp/build.gradle
@@ -1,0 +1,18 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22'
+        classpath 'com.google.dagger:hilt-android-gradle-plugin:2.44'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/NativeLoginApp/gradle/wrapper/gradle-wrapper
+++ b/NativeLoginApp/gradle/wrapper/gradle-wrapper
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+java -jar "$0.jar" "$@"

--- a/NativeLoginApp/gradle/wrapper/gradle-wrapper.properties
+++ b/NativeLoginApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/NativeLoginApp/gradlew
+++ b/NativeLoginApp/gradlew
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+if [ -d "$DIR/gradle/wrapper" ]; then
+  JAVA_HOME=${JAVA_HOME:-$(dirname $(dirname $(readlink -f $(which javac))))}
+  "$DIR/gradle/wrapper/gradle-wrapper" "$@"
+else
+  echo "Gradle wrapper not found"
+  exit 1
+fi

--- a/NativeLoginApp/settings.gradle
+++ b/NativeLoginApp/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "NativeLoginApp"
+include(":app")


### PR DESCRIPTION
## Summary
- add new Android project with AWS Lambda login using Kotlin
- use Jetpack Compose, MVI state handling, and Hilt
- show AWSCredentialManager and repository for AWS Lambda calls
- implement navigation from login to OTP placeholder

## Testing
- `./gradlew assembleDebug` *(fails: unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_685904f4625483328178d8f893b7b3c7